### PR TITLE
Update unbound-blacklist-fetch.sh

### DIFF
--- a/unbound-blacklist-fetch.sh
+++ b/unbound-blacklist-fetch.sh
@@ -93,7 +93,8 @@ echo 'server:' > ${FILE}
   cat ${TEMP}/hosts-* \
   | grep -v '^#' \
   | grep -v '^$' \
-  | awk '{print $2}'
+  | awk '{print $2}' \
+  | tr '[:upper:]' '[:lower:]'
 
 ) \
   | sed -e s/$'\r'//g \


### PR DESCRIPTION
Make all hosts in lowercase to prevent unbound warnings about duplicated zones.