### PR TITLE
Adapt for FreeBSD and OpenBSD, plus filter out additional invalid characters

### DIFF
--- a/unbound-blacklist-fetch-huge.sh
+++ b/unbound-blacklist-fetch-huge.sh
@@ -78,7 +78,7 @@ ${FETCHCMD} \
   1> ${TEMP}/lists-unbound 2> /dev/null
 
 [ "${ECHO}" != "0" ] && echo "fetch: ${TEMP}/lists-domains"
-curl \
+${FETCHCMD} \
  'https://pgl.yoyo.org/adservers/serverlist.php?mimetype=plaintext&hostformat=plain'                                                                                   \
   http://blacklists.ntop.org/adblocker-hostnames.txt                                                                                                                   \
   http://thedumbterminal.co.uk/files/services/squidblockedsites/blocked.txt                                                                                            \
@@ -181,7 +181,7 @@ buy.geni.us
 EOF
 
 [ "${ECHO}" != "0" ] && echo "fetch: ${TEMP}/lists-hosts"
-curl \
+${FETCHCMD} \
   http://sysctl.org/cameleon/hosts                                                                                                          \
   http://winhelp2002.mvps.org/hosts.txt                                                                                                     \
   https://adaway.org/hosts.txt                                                                                                              \

--- a/unbound-blacklist-fetch-huge.sh
+++ b/unbound-blacklist-fetch-huge.sh
@@ -36,7 +36,6 @@
 
 # SETTINGS
 WHICHOS=$(uname)
-[ "${ECHO}" != "0" ] && echo "running on '${WHICHOS}'"
 
 if [ "${WHICHOS}" = 'FreeBSD' ]
 then


### PR DESCRIPTION
1. Test for OS. Adapt file location and fetch command for FreeBSD and OpenBSD. (Others can be added as desired.)
2. Filter out carriage returns (^M) and hash marks (#) from domain names, probably artifacts of upstream.
3. For OpenBSD, check the resulting configuration file. If valid, then restart unbound. (Others can be added as desired.)
4. Whitelist two Amazon domains.