### PR TITLE
Typo in "usage" of vmc.sh

### DIFF
--- a/vmc.sh
+++ b/vmc.sh
@@ -48,7 +48,7 @@ __usage() {
 usage:
   ${NAME}                -  list VMs
   ${NAME} -h | --help    -  print this help information
-  ${NAME} -l | --unlock  -  unlock are locked VMs
+  ${NAME} -l | --unlock  -  unlock all locked VMs
   ${NAME} -m | --mac     -  check for duplicated MAC addresses in VMs
   ${NAME} -u | --uuid    -  check for duplicated UUID values in VMs
 


### PR DESCRIPTION
Typos are sneaky! 95% sure "unlock **are** locked VMs" was supposed to be "unlock **all** locked VMs" but I guess it could be "unlock **our** locked VMs" or some such :-) 